### PR TITLE
Fixes URLs broken due to non-ASCII characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# imagenet-download
-Python scripts to download imagenet images and pre-proccess them
+# ImageNet URL Downloader
 
-example usage:
+Python utility script for downloading subtrees of ImageNet using the URLS provided by the ImageNet API.
 
- ./imagenetDownloader.py  n03489162 ../dataset --humanreadable -F --images=50 --minsize=7000 -j10
- 
-In order to download 50 images from any category under any subtree (-F) of the handtools (n03489162), running 10 threads in parallel, and only downloading images larger than 7kB.
+This repository is a fork of https://github.com/itf/imagenet-download and includes some upgrades to allow for more robust downloads:
+
+- [x] Image downloads don't fail if the URL (or rather IRI) includes non-ASCII characters
+- [ ] Retry getting list of URLs if the ImageNet API does not respond temporarily (this happens very frequently as of now!)
+- [ ] Resume downloads
+
+
+__Please note__ that this project is currently WIP (as of June 2019) and is expected to receive major updates during the next days!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ImageNet URL Downloader
 
-Python utility script for downloading subtrees of ImageNet using the URLS provided by the ImageNet API.
+Python utility script for downloading subtrees of ImageNet using the URLs provided by the ImageNet API.
 
 This repository is a fork of https://github.com/itf/imagenet-download and includes some upgrades to allow for more robust downloads:
 

--- a/imagenetDownloader.py
+++ b/imagenetDownloader.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+
+# Based on a script by Ivan T. F. Antunes F. With the following copyright
 # Copyright (c) 2017 Ivan T. F. Antunes F.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/imagenetDownloader.py
+++ b/imagenetDownloader.py
@@ -51,11 +51,17 @@ class DownloadError(Exception):
     def __init__(self, message=""):
         self.message = message
 
+def fixURLEncoding(url):
+    """Fixes non-ASCII characters in URLs"""
+    url = urllib.parse.quote(url.encode('utf8'), ':/?=&')
+    return url
+
 def download(url, timeout, retry, sleep=0.8):
     """Downloads a file at given URL."""
     count = 0
     while True:
         try:
+            url = fixURLEncoding(url)
             f = urllib.request.urlopen(url, timeout=timeout)
             if f is None:
                 raise DownloadError('Cannot open URL' + url)


### PR DESCRIPTION
Quite some URLs (or rather IRIs) were skipped since urllib cannot handle non-ASCII characters (such as chinese characters). Added a function that fixes these URLs. 